### PR TITLE
Registration and news feature

### DIFF
--- a/cypress/fixtures/crypto_news.json
+++ b/cypress/fixtures/crypto_news.json
@@ -1,0 +1,53 @@
+{
+  "articles": [
+    {
+      "title": "Brave annonce de nouvelles fonctionnalités pour accélérer l’adoption des crypto-monnaies",
+      "urlToImage": "https://pic.clubic.com/v1/images/1864305/raw?width=900&height=600&fit=max&hash=a3fac0b267b97c50bef2980aa5ee0b19650551b2",
+      "url": "https://www.clubic.com/antivirus-securite-informatique/cryptage-cryptographie/crypto-monnaie/actualite-363158-brave-annonce-des-nouvelles-fonctionnalites-pour-accelerer-l-adoption-des-crypto-monnaies.html",
+      "description": "La nouvelle version du navigateur Brave  comprendra un nouveau portefeuille Ethereum (ETH) qui intégrera un agrégateur d’exchanges décentralisés (DEX) et d’autres fonctionnalités.",
+      "date": "2021-02-26"
+    },
+    {
+      "title": "Many pieces of the Diem puzzle still missing as launch gets delayed",
+      "urlToImage": "https://images.cointelegraph.com/images/1200_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjEtMDIvNzA0N2UwZmUtNTRhYS00NTRhLTliNDctYjBiZGVmNjgyODJiLmpwZw==.jpg",
+      "url": "https://cointelegraph.com/news/many-pieces-of-the-diem-puzzle-still-missing-as-launch-gets-delayed",
+      "description": "Diem is still awaiting regulatory approval from Swiss authorities but other governments are insisting on stricter regulations for privately-issued stablecoins.",
+      "date": "2021-02-26"
+    },
+    {
+      "title": "First Boulevard raises $5M for its digital bank aimed at Black America",
+      "urlToImage": "https://techcrunch.com/wp-content/uploads/2012/11/startup-seed-funding-300x200.jpg?w=300",
+      "url": "http://techcrunch.com/2021/02/26/first-boulevard-raises-5m-for-its-digital-bank-aimed-at-black-america/",
+      "description": "The murder of George Floyd last May ignited many things in the United States last year — one of which that was perhaps unexpected: a rise in the number of digital banks targeting the Black community. Some members of the Black community took their belief that …",
+      "date": "2021-02-26"
+    },
+    {
+      "title": "First Boulevard raises $5M for its digital bank aimed at Black America",
+      "urlToImage": "https://s.yimg.com/uu/api/res/1.2/pkT6C0EFhEcZR_cLS.xngg--~B/aD0yMDA7dz0zMDA7YXBwaWQ9eXRhY2h5b24-/https://media.zenfs.com/en/techcrunch_350/7ba20d8a9bd281ec99b2c7b6b1e42a37",
+      "url": "https://techcrunch.com/2021/02/26/first-boulevard-raises-5m-for-its-digital-bank-aimed-at-black-america/",
+      "description": "The murder of George Floyd last May ignited many things in the United States last year -- one of which that was perhaps unexpected: a rise in the number of...",
+      "date": "2021-02-26"
+    },
+    {
+      "title": "After a Year of Quantum Advances, the Time to Protect Is Now",
+      "urlToImage": "https://img.deusm.com/darkreading/dr_staff_125x125.jpg",
+      "url": "https://www.darkreading.com/vulnerabilities---threats/after-a-year-of-quantum-advances-the-time-to-protect-is-now/a/d-id/1340180",
+      "description": "Innovations in quantum computing mean enterprise and manufacturing organizations need to start planning now to defend against new types of cybersecurity threats.",
+      "date": "2021-02-26"
+    },
+    {
+      "title": "How to sell a cat GIF for half a million dollars",
+      "urlToImage": "https://content.fortune.com/wp-content/uploads/2021/02/GettyImages-1300475411.jpg?resize=1200,600",
+      "url": "https://fortune.com/2021/02/26/how-to-sell-a-cat-gif-for-half-a-million-dollars/",
+      "description": "Non-fungible tokens, or NFTs, allow digital art lovers to buy works like Nyan Cat using crypto currency technology on a blackchain.",
+      "date": "2021-02-26"
+    },
+    {
+      "title": "Le GIF de Nyan Cat a été vendu pour un demi-million de dollars grâce à la blockchain",
+      "urlToImage": "https://lareclame.fr/wp-content/uploads/2021/02/nyancat-topjpg.jpg",
+      "url": "https://lareclame.fr/nyan-cat-chris-torres-2021-245941",
+      "description": "On ne présente plus Nyan, le meme de chat volant qui laisse une traînée d’arc-en-ciel, ni sa musique entêtante. La vidéo a été diffusée sur Youtube pour la première fois en 2011, et a fait plusieurs millions de vues. Ce … Continuer la lecture →\nThe post Le GI…",
+      "date": "2021-02-26"
+    }
+  ]
+}

--- a/cypress/fixtures/registered_user.json
+++ b/cypress/fixtures/registered_user.json
@@ -1,0 +1,10 @@
+{
+  "status": "success",
+  "data": {
+    "id": 1,
+    "email": "user@email.com",
+    "provider": "email",
+    "uid": "user@email.com",
+    "allow_password_change": false
+  }
+}

--- a/cypress/fixtures/sign_in_response.json
+++ b/cypress/fixtures/sign_in_response.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+      "email": "test@gmail.com",
+      "uid": "test@gmail.com",
+      "id": 11,
+      "provider": "email",
+      "allow_password_change": false
+  }
+}

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -75,7 +75,7 @@ describe('User can access news tab', () => {
       })
       cy.get('[data-cy="register-button"]').click()
       cy.get('[data-cy="registration-form"]').within(() => {
-        cy.get('[data-cy="email-field"]').type('user@email.com')
+        cy.get('[data-cy="email-field"]').type('test@email.com')
         cy.get('[data-cy="password-field"]').type('password')
         cy.get('[data-cy="password-confirmation-field"]').type('password')
         cy.get('[data-cy="submit"]').click()

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -23,15 +23,19 @@ describe('User can access news tab', () => {
       cy.visit('/')
     })
 
-    it('user can register and then click on news tab', () => {
+    it('user can register and then see content of Crypto News tab', () => {
+      cy.get('.ui.pointing.secondary.menu').within(() => {
+        cy.get('a').eq(1).click()
+      })
       cy.get('[data-cy="register-button"]').click()
       cy.get('[data-cy="registration-form"]').within(() => {
         cy.get('[data-cy="email-field"]').type('user@email.com')
         cy.get('[data-cy="password-field"]').type('password')
         cy.get('[data-cy="password-confirmation-field"]').type('password')
         cy.get('[data-cy="submit"]').click()
-        cy.get('[data-cy="news-tab"]').click()
       })
+      cy.get('[data-cy="news-header"]').should('contain', 'Latest Crypto News')
+      cy.get('[data-cy="news-list-wrapper]').find('[data-cy="news-article"]').should('have.length', 7)
     })
   })
 })

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -15,7 +15,7 @@ describe('User can access news tab', () => {
       cy.route({
         method: "POST",
         url: "http://localhost:3000/api/auth",
-        response: "fixture:register_user.json",
+        response: "fixture:registered_user.json",
         headers: {
           uid: 'user@email.com'
         }

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -1,0 +1,37 @@
+describe('User can access news tab', () => {
+  describe('successfully as authenticated user', () => {
+    beforeEach(() => {
+      cy.server()
+      cy.route({
+        method: "GET",
+        url: "http://localhost:3000/api/markets?*",
+        response: 'fixture:market_cap.json',
+      })
+      cy.route({
+        method: "GET",
+        url: "http://localhost:3000/api/currencies",
+        response: 'fixture:currencies.json',
+      })
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/auth",
+        response: "fixture:register_user.json",
+        headers: {
+          uid: 'user@email.com'
+        }
+      });
+      cy.visit('/')
+    })
+
+    it('user can register and then click on news tab', () => {
+      cy.get('[data-cy="register-button"]').click()
+      cy.get('[data-cy="registration-form"]').within(() => {
+        cy.get('[data-cy="email-field"]').type('user@email.com')
+        cy.get('[data-cy="password-field"]').type('password')
+        cy.get('[data-cy="password-confirmation-field"]').type('password')
+        cy.get('[data-cy="submit"]').click()
+        cy.get('[data-cy="news-tab"]').click()
+      })
+    })
+  })
+})

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -22,7 +22,7 @@ describe('User can access news tab', () => {
       })
       cy.route({
         method: "GET",
-        url: "http://localhost:3000/api/news",
+        url: "http://localhost:3000/api/news?*",
         response: 'fixture:crypto_news.json',
       })
       cy.visit('/')

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -57,6 +57,38 @@ describe('User can access news tab', () => {
       cy.get('.ui.items').find('[data-cy="news-article"]').should('have.length', 7)
     })
   })
+
+  describe('successfully through signing in', () => {
+    beforeEach(() => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/auth/sign_in",
+        response: "fixture:sign_in_response.json",
+        headers: {
+          uid: 'test@email.com'
+        }
+      })
+      cy.route({
+        method: "GET",
+        url: "http://localhost:3000/api/news?*",
+        response: 'fixture:crypto_news.json',
+      })
+      cy.get('[data-cy="register-button"]').click()
+      cy.get('[data-cy="registration-form"]').within(() => {
+        cy.get('[data-cy="email-field"]').type('user@email.com')
+        cy.get('[data-cy="password-field"]').type('password')
+        cy.get('[data-cy="password-confirmation-field"]').type('password')
+        cy.get('[data-cy="submit"]').click()
+      })
+    })
+    
+    it('user can register and then see content of Crypto News tab', () => {
+      cy.get('[data-cy="news-header"]').should('contain', 'Latest Crypto News')
+      cy.get('[data-cy="news-auth-error"]').should('not.exist')
+      cy.get('.ui.items').find('[data-cy="news-article"]').should('have.length', 7)
+    })
+  })
+
   describe('unsuccessfully as unauthenticated user', () => {
     beforeEach(() => {
       cy.route({

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -1,17 +1,24 @@
 describe('User can access news tab', () => {
+  beforeEach(() => {
+    cy.server()
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/markets?*",
+      response: 'fixture:market_cap.json',
+    })
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/currencies",
+      response: 'fixture:currencies.json',
+    })
+    cy.visit('/')
+    cy.get('.ui.pointing.secondary.menu').within(() => {
+      cy.get('a').eq(1).click()
+    })
+  })
+
   describe('successfully as authenticated user', () => {
     beforeEach(() => {
-      cy.server()
-      cy.route({
-        method: "GET",
-        url: "http://localhost:3000/api/markets?*",
-        response: 'fixture:market_cap.json',
-      })
-      cy.route({
-        method: "GET",
-        url: "http://localhost:3000/api/currencies",
-        response: 'fixture:currencies.json',
-      })
       cy.route({
         method: "POST",
         url: "http://localhost:3000/api/auth",
@@ -25,15 +32,6 @@ describe('User can access news tab', () => {
         url: "http://localhost:3000/api/news?*",
         response: 'fixture:crypto_news.json',
       })
-      cy.visit('/')
-    })
-
-    it('user can register and then see content of Crypto News tab', () => {
-      cy.get('.ui.pointing.secondary.menu').within(() => {
-        cy.get('a').eq(1).click()
-      })
-      cy.get('[data-cy="news-header"]').should('contain', 'Latest Crypto News')
-      cy.get('[data-cy="news-auth-error"]').should('contain', 'You will need to login in order to see the news.')
       cy.get('[data-cy="register-button"]').click()
       cy.get('[data-cy="registration-form"]').within(() => {
         cy.get('[data-cy="email-field"]').type('user@email.com')
@@ -41,9 +39,49 @@ describe('User can access news tab', () => {
         cy.get('[data-cy="password-confirmation-field"]').type('password')
         cy.get('[data-cy="submit"]').click()
       })
-      cy.get('[data-cy="news-auth-error"]').should('not.exist')
+    })
 
+    it('user can register and then see content of Crypto News tab', () => {
+      cy.get('[data-cy="news-header"]').should('contain', 'Latest Crypto News')
+      cy.get('[data-cy="news-auth-error"]').should('not.exist')
       cy.get('.ui.items').find('[data-cy="news-article"]').should('have.length', 7)
+    })
+
+    it('user can change tabs and still see the news', () => {
+      cy.get('.ui.pointing.secondary.menu').within(() => {
+        cy.get('a').eq(0).click()
+      })
+      cy.get('.ui.pointing.secondary.menu').within(() => {
+        cy.get('a').eq(1).click()
+      })
+      cy.get('.ui.items').find('[data-cy="news-article"]').should('have.length', 7)
+    })
+  })
+  describe('unsuccessfully as unauthenticated user', () => {
+    beforeEach(() => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/auth",
+        response: {
+          errors: {
+            full_messages: ["Invalid login credentials. Please try again."],
+          },
+          success: false,
+        },
+        status: 401
+      })
+      cy.get('[data-cy="register-button"]').click()
+      cy.get('[data-cy="registration-form"]').within(() => {
+        cy.get('[data-cy="email-field"]').type('user@email.com')
+        cy.get('[data-cy="password-field"]').type('password')
+        cy.get('[data-cy="password-confirmation-field"]').type('password')
+        cy.get('[data-cy="submit"]').click()
+      })
+    })
+
+    it('Displays a login message', () => {
+      cy.get('.ui.dimmer').click("topLeft")
+      cy.get('[data-cy="news-auth-error"]').should('contain', 'You will need to login in order to see the news.')
     })
   })
 })

--- a/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
+++ b/cypress/integration/AuthenticatedUsersCanAccessNewsTab.feature.js
@@ -19,7 +19,12 @@ describe('User can access news tab', () => {
         headers: {
           uid: 'user@email.com'
         }
-      });
+      })
+      cy.route({
+        method: "GET",
+        url: "http://localhost:3000/api/news",
+        response: 'fixture:crypto_news.json',
+      })
       cy.visit('/')
     })
 
@@ -27,6 +32,8 @@ describe('User can access news tab', () => {
       cy.get('.ui.pointing.secondary.menu').within(() => {
         cy.get('a').eq(1).click()
       })
+      cy.get('[data-cy="news-header"]').should('contain', 'Latest Crypto News')
+      cy.get('[data-cy="news-auth-error"]').should('contain', 'You will need to login in order to see the news.')
       cy.get('[data-cy="register-button"]').click()
       cy.get('[data-cy="registration-form"]').within(() => {
         cy.get('[data-cy="email-field"]').type('user@email.com')
@@ -34,8 +41,9 @@ describe('User can access news tab', () => {
         cy.get('[data-cy="password-confirmation-field"]').type('password')
         cy.get('[data-cy="submit"]').click()
       })
-      cy.get('[data-cy="news-header"]').should('contain', 'Latest Crypto News')
-      cy.get('[data-cy="news-list-wrapper]').find('[data-cy="news-article"]').should('have.length', 7)
+      cy.get('[data-cy="news-auth-error"]').should('not.exist')
+
+      cy.get('.ui.items').find('[data-cy="news-article"]').should('have.length', 7)
     })
   })
 })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import MarketCapCard from './components/MarketCapCard'
+import CryptoNews from './components/CryptoNews'
 import RegistrationModal from './components/RegistrationModal'
 import CryptoCard from './components/CryptoCards'
 import './app.css'
-import { Grid, Tab } from 'semantic-ui-react';
+import { Grid, Tab, Item } from 'semantic-ui-react';
 
 const App = () => {
   const [authenticated, setAuthenticated] = useState(false)
@@ -22,12 +23,12 @@ const App = () => {
             </Grid.Row>
           </Grid>
         </Tab.Pane>
-
     },
     {
       menuItem: 'Crypto News',
       render: () => <Tab.Pane attached={false}>
         <Grid centered textAlign="center">
+          <CryptoNews authenticated={authenticated}/>
         </Grid>
       </Tab.Pane>,
     },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,9 @@ const App = () => {
             <Grid.Row columns={2}>
               <MarketCapCard />
             </Grid.Row>
-            <CryptoCard />
+            <Grid.Row columns={3} data-cy="crypto-cards">
+              <CryptoCard />
+            </Grid.Row>
           </Grid>
         </Tab.Pane>
     },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import CryptoNews from './components/CryptoNews'
 import RegistrationModal from './components/RegistrationModal'
 import CryptoCard from './components/CryptoCards'
 import './app.css'
-import { Grid, Tab, Item } from 'semantic-ui-react';
+import { Grid, Tab, Item, Header } from 'semantic-ui-react';
 
 const App = () => {
   const [authenticated, setAuthenticated] = useState(false)
@@ -15,6 +15,7 @@ const App = () => {
       render: () =>
         <Tab.Pane attached={false}>
           <Grid centered textAlign="center">
+            <Header className="page-header" data-cy="news-header">Welcome to DeFi Unchained!</Header>
             <Grid.Row>
               <MarketCapCard />
             </Grid.Row>
@@ -26,18 +27,24 @@ const App = () => {
     },
     {
       menuItem: 'Crypto News',
-      render: () => <Tab.Pane attached={false}>
-        <Grid >
-          <CryptoNews authenticated={authenticated} />
-        </Grid>
-      </Tab.Pane>,
+      render: () =>
+        <Tab.Pane attached={false}>
+          <Grid>
+            <Grid.Row centered>
+              <Header textAlign="center" className="page-header" data-cy="news-header">Latest Crypto News</Header>
+            </Grid.Row>
+            <CryptoNews authenticated={authenticated} />
+          </Grid>
+        </Tab.Pane>,
     },
     {
       menuItem: 'Buy Signals',
-      render: () => <Tab.Pane attached={false}>
-        <Grid centered textAlign="center">
-        </Grid>
-      </Tab.Pane>,
+      render: () =>
+        <Tab.Pane attached={false}>
+          <Grid centered textAlign="center">
+            <Header className="page-header" data-cy="news-header">Your Daily Buy Signals!</Header>
+          </Grid>
+        </Tab.Pane>,
     },
     {
       menuItem: <RegistrationModal setAuthenticated={setAuthenticated} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,17 @@
-import React from 'react';
+import React, {useState} from 'react';
 import MarketCapCard from './components/MarketCapCard'
+import RegistrationModal from './components/RegistrationModal'
 import CryptoCard from './components/CryptoCards'
 import './app.css'
 import { Grid } from 'semantic-ui-react';
 
 const App = () => {
+  const [authenticated, setAuthenticated] = useState(false)
+
   return (
     <Grid centered textAlign="center">
       <Grid.Row>
+        <RegistrationModal setAuthenticated={() => setAuthenticated}/>
         <MarketCapCard />
       </Grid.Row>
       <Grid.Row data-cy="crypto-cards"columns={3}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,7 @@ const App = () => {
   ]
 
   return (
-    <Tab menu={{ secondary: true, pointing: true }} panes={panes} />
+    <Tab menu={{ secondary: true, pointing: true, renderActiveOnly: false }} panes={panes} />
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,23 +1,62 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import MarketCapCard from './components/MarketCapCard'
 import RegistrationModal from './components/RegistrationModal'
 import CryptoCard from './components/CryptoCards'
 import './app.css'
-import { Grid } from 'semantic-ui-react';
+import { Grid, Tab } from 'semantic-ui-react';
 
 const App = () => {
   const [authenticated, setAuthenticated] = useState(false)
 
+  const panes = [
+    {
+      menuItem: 'Crypto Info',
+      render: () =>
+        <Tab.Pane attached={false}>
+          <Grid centered textAlign="center">
+            {!authenticated && (
+              <Grid.Row>
+                <RegistrationModal setAuthenticated={setAuthenticated} />
+              </Grid.Row>
+            )}
+            <Grid.Row>
+              <MarketCapCard />
+            </Grid.Row>
+            <Grid.Row data-cy="crypto-cards" columns={3}>
+              <CryptoCard />
+            </Grid.Row>
+          </Grid>
+        </Tab.Pane>
+
+    },
+    {
+      menuItem: 'Crypto News',
+      render: () => <Tab.Pane attached={false}>
+        <Grid centered textAlign="center">
+          {!authenticated && (
+            <Grid.Row>
+              <RegistrationModal setAuthenticated={setAuthenticated} />
+            </Grid.Row>
+          )}
+        </Grid>
+      </Tab.Pane>,
+    },
+    {
+      menuItem: 'Buy Signals',
+      render: () => <Tab.Pane attached={false}>
+        <Grid centered textAlign="center">
+          {!authenticated && (
+            <Grid.Row>
+              <RegistrationModal setAuthenticated={setAuthenticated} />
+            </Grid.Row>
+          )}
+        </Grid>
+      </Tab.Pane>,
+    },
+  ]
+
   return (
-    <Grid centered textAlign="center">
-      <Grid.Row>
-        <RegistrationModal setAuthenticated={() => setAuthenticated}/>
-        <MarketCapCard />
-      </Grid.Row>
-      <Grid.Row data-cy="crypto-cards"columns={3}>
-        <CryptoCard />
-      </Grid.Row>
-    </Grid>
+    <Tab menu={{ secondary: true, pointing: true }} panes={panes} />
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,12 +16,10 @@ const App = () => {
         <Tab.Pane attached={false}>
           <Grid centered textAlign="center">
             <Header className="page-header" data-cy="news-header">Welcome to DeFi Unchained!</Header>
-            <Grid.Row>
+            <Grid.Row columns={2}>
               <MarketCapCard />
             </Grid.Row>
-            <Grid.Row data-cy="crypto-cards" columns={3}>
-              <CryptoCard />
-            </Grid.Row>
+            <CryptoCard />
           </Grid>
         </Tab.Pane>
     },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,11 +14,6 @@ const App = () => {
       render: () =>
         <Tab.Pane attached={false}>
           <Grid centered textAlign="center">
-            {!authenticated && (
-              <Grid.Row>
-                <RegistrationModal setAuthenticated={setAuthenticated} />
-              </Grid.Row>
-            )}
             <Grid.Row>
               <MarketCapCard />
             </Grid.Row>
@@ -33,11 +28,6 @@ const App = () => {
       menuItem: 'Crypto News',
       render: () => <Tab.Pane attached={false}>
         <Grid centered textAlign="center">
-          {!authenticated && (
-            <Grid.Row>
-              <RegistrationModal setAuthenticated={setAuthenticated} />
-            </Grid.Row>
-          )}
         </Grid>
       </Tab.Pane>,
     },
@@ -45,14 +35,12 @@ const App = () => {
       menuItem: 'Buy Signals',
       render: () => <Tab.Pane attached={false}>
         <Grid centered textAlign="center">
-          {!authenticated && (
-            <Grid.Row>
-              <RegistrationModal setAuthenticated={setAuthenticated} />
-            </Grid.Row>
-          )}
         </Grid>
       </Tab.Pane>,
     },
+    {
+      menuItem: <RegistrationModal setAuthenticated={setAuthenticated}/>
+    }
   ]
 
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,49 +1,49 @@
-import React, { useState } from 'react';
+import React, { useState} from 'react';
 import MarketCapCard from './components/MarketCapCard'
 import CryptoNews from './components/CryptoNews'
 import RegistrationModal from './components/RegistrationModal'
 import CryptoCard from './components/CryptoCards'
 import './app.css'
-import { Grid, Tab, Item, Header } from 'semantic-ui-react';
+import { Grid, Tab, Header, Loader, Dimmer } from 'semantic-ui-react';
 
 const App = () => {
   const [authenticated, setAuthenticated] = useState(false)
+  const [active, setActive] = useState(true)
 
   const panes = [
     {
       menuItem: 'Crypto Info',
       render: () =>
         <Tab.Pane attached={false}>
-          <Grid centered textAlign="center">
+          <Dimmer.Dimmable as={Grid} centered blurring dimmed={active}>
             <Header className="page-header" data-cy="news-header">Welcome to DeFi Unchained!</Header>
+            <Dimmer active={active}>
+              <Loader size="large" content='Just a moment!' />
+            </Dimmer>
             <Grid.Row columns={2}>
               <MarketCapCard />
             </Grid.Row>
             <Grid.Row columns={3} data-cy="crypto-cards">
-              <CryptoCard />
+              <CryptoCard setActive={setActive} />
             </Grid.Row>
-          </Grid>
+          </Dimmer.Dimmable>
         </Tab.Pane>
     },
     {
       menuItem: 'Crypto News',
       render: () =>
-        <Tab.Pane attached={false}>
-          <Grid>
-            <Grid.Row centered>
-              <Header textAlign="center" className="page-header" data-cy="news-header">Latest Crypto News</Header>
-            </Grid.Row>
-            <CryptoNews authenticated={authenticated} />
-          </Grid>
+        <Tab.Pane as={Grid} attached={false}>
+          <Grid.Row centered>
+            <Header textAlign="center" className="page-header" data-cy="news-header">Latest Crypto News</Header>
+          </Grid.Row>
+          <CryptoNews authenticated={authenticated} />
         </Tab.Pane>,
     },
     {
       menuItem: 'Buy Signals',
       render: () =>
-        <Tab.Pane attached={false}>
-          <Grid centered textAlign="center">
-            <Header className="page-header" data-cy="news-header">Your Daily Buy Signals!</Header>
-          </Grid>
+        <Tab.Pane as={Grid} centered attached={false}>
+          <Header style={{ marginTop: 25 }} className="page-header" data-cy="news-header">Your Daily Buy Signals!</Header>
         </Tab.Pane>,
     },
     {
@@ -52,7 +52,14 @@ const App = () => {
   ]
 
   return (
-    <Tab menu={{ secondary: true, pointing: true, color: 'teal' }} panes={panes} />
+    <Tab
+      menu={{ secondary: true, pointing: true, color: 'teal' }}
+      panes={panes}
+      onTabChange={(event) => {
+        if (event.target.className === 'item') {
+          setActive(true)
+        }
+      }} />
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,8 +27,8 @@ const App = () => {
     {
       menuItem: 'Crypto News',
       render: () => <Tab.Pane attached={false}>
-        <Grid centered textAlign="center">
-          <CryptoNews authenticated={authenticated}/>
+        <Grid >
+          <CryptoNews authenticated={authenticated} />
         </Grid>
       </Tab.Pane>,
     },
@@ -40,12 +40,12 @@ const App = () => {
       </Tab.Pane>,
     },
     {
-      menuItem: <RegistrationModal setAuthenticated={setAuthenticated}/>
+      menuItem: <RegistrationModal setAuthenticated={setAuthenticated} />
     }
   ]
 
   return (
-    <Tab menu={{ secondary: true, pointing: true, renderActiveOnly: false }} panes={panes} />
+    <Tab menu={{ secondary: true, pointing: true, color: 'teal' }} panes={panes} />
   );
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -18,7 +18,7 @@ body {
 }
 
 .news-wrapper {
-  margin: 0 175px!important;
+  margin: 0 20%!important;
 }
 
 .ui.grid.blurring {

--- a/src/app.css
+++ b/src/app.css
@@ -1,13 +1,37 @@
 * {
   margin: 0;
-  padding: 0
+  padding: 0;
+
+}
+
+body {
+  background-image: url("https://images.unsplash.com/photo-1496065187959-7f07b8353c55?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=1050&q=80")!important;
+  background-size: cover!important;
+}
+
+.ui.secondary.pointing.menu .item {
+  color: white;
+  margin-left: 15px!important;
+}
+.ui.secondary.pointing.menu .item:hover {
+  color: teal!important;
+}
+
+.ui.segment.active.tab{
+  background-color: transparent!important;
+}
+
+.page-header {
+  font-size: 40px!important;
+  color: white!important
 }
 
 .market-card {
-  margin-top: 50px!important;
   width: 500px!important;
   text-align: center;
 }
+
+
 
 .ui.card img {
   width: 30px;

--- a/src/app.css
+++ b/src/app.css
@@ -14,3 +14,7 @@
   height: 30px;
   padding-left: 10px;
 }
+
+.ui.teal.button {
+  margin-left: 50%
+}

--- a/src/app.css
+++ b/src/app.css
@@ -21,11 +21,6 @@ body {
   margin: 0 175px!important;
 }
 
-.news-article {
-  padding-bottom: 5px!important;
-  border-bottom: rgb(32, 31, 31) solid 1px!important;
-}
-
 .ui.segment.active.tab{
   background-color: transparent!important;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -21,6 +21,10 @@ body {
   margin: 0 175px!important;
 }
 
+.ui.grid.blurring {
+  min-height: 100vh!important;
+}
+
 .ui.segment.active.tab{
   background-color: transparent!important;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -31,7 +31,9 @@ body {
   text-align: center;
 }
 
-
+.ui.login-modal {
+  background-image: url("https://images.unsplash.com/photo-1451187580459-43490279c0fa?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1052&q=80");
+}
 
 .ui.card img {
   width: 30px;

--- a/src/app.css
+++ b/src/app.css
@@ -17,6 +17,15 @@ body {
   color: teal!important;
 }
 
+.news-wrapper {
+  margin: 0 175px!important;
+}
+
+.news-article {
+  padding-bottom: 5px!important;
+  border-bottom: rgb(32, 31, 31) solid 1px!important;
+}
+
 .ui.segment.active.tab{
   background-color: transparent!important;
 }

--- a/src/components/CryptoCards.jsx
+++ b/src/components/CryptoCards.jsx
@@ -18,27 +18,36 @@ const CryptoCards = () => {
     }, 1500)
   }, [])
 
-const cryptoCards = currencies.map((coin, i) => {
+  const cryptoCards = currencies.map((coin, i) => {
+    return (
+      <Grid.Column key={i}>
+        <Card data-cy="crypto-card">
+          <Card.Content>
+            <Card.Header data-cy="crypto-header">
+              {coin.name}
+              <span><img alt={coin.name} src={coin.logo} /></span>
+            </Card.Header>
+            <Card.Description data-cy="crypto-price">${coin.price}</Card.Description>
+            <Card.Description data-cy="crypto-change">{coin.change.toFixed(2)}%</Card.Description>
+          </Card.Content>
+        </Card>
+      </Grid.Column>
+    )
+  })
   return (
-    <Grid.Column  key={i}>
-      <Card data-cy="crypto-card">
-        <Card.Content>
-          <Card.Header data-cy="crypto-header">
-            {coin.name}
-            <span><img alt={coin.name} src={coin.logo} /></span>
-          </Card.Header>
-          <Card.Description data-cy="crypto-price">${coin.price}</Card.Description>
-          <Card.Description data-cy="crypto-change">{coin.change.toFixed(2)}%</Card.Description>
-        </Card.Content>
-      </Card>
-    </Grid.Column>
+    <>
+      {errorMessage ? <h2>{errorMessage} </h2> : (
+        <>
+          <Grid.Row textAlign="center" columns={3}>
+            {cryptoCards.slice(0, 3)}
+          </Grid.Row>
+          <Grid.Row columns={3}>
+            {cryptoCards.splice(3, 3)}
+          </Grid.Row>
+        </>
+      )}
+    </>
   )
-})
-return (
-  <>
-    {errorMessage ? <h2>{errorMessage} </h2>: cryptoCards}
-  </>
-)
 }
 
 export default CryptoCards

--- a/src/components/CryptoCards.jsx
+++ b/src/components/CryptoCards.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { getCoinData } from '../modules/dataCenter'
 import { Card, Grid } from 'semantic-ui-react';
 
-const CryptoCards = () => {
+const CryptoCards = (props) => {
   const [currencies, setCurrencies] = useState([])
   const [errorMessage, setErrorMessage] = useState()
 
@@ -15,6 +15,7 @@ const CryptoCards = () => {
       catch (error) {
         setErrorMessage("Couldn't render information. Please update.")
       }
+      props.setActive(false)
     }, 1500)
   }, [])
 

--- a/src/components/CryptoCards.jsx
+++ b/src/components/CryptoCards.jsx
@@ -36,16 +36,7 @@ const CryptoCards = () => {
   })
   return (
     <>
-      {errorMessage ? <h2>{errorMessage} </h2> : (
-        <>
-          <Grid.Row textAlign="center" columns={3}>
-            {cryptoCards.slice(0, 3)}
-          </Grid.Row>
-          <Grid.Row columns={3}>
-            {cryptoCards.splice(3, 3)}
-          </Grid.Row>
-        </>
-      )}
+      {errorMessage ? <h2 style={{color: "white"}}>{errorMessage} </h2> : cryptoCards }
     </>
   )
 }

--- a/src/components/CryptoCards.jsx
+++ b/src/components/CryptoCards.jsx
@@ -20,7 +20,7 @@ const CryptoCards = () => {
 
 const cryptoCards = currencies.map((coin, i) => {
   return (
-    <Grid.Column key={i}>
+    <Grid.Column  key={i}>
       <Card data-cy="crypto-card">
         <Card.Content>
           <Card.Header data-cy="crypto-header">

--- a/src/components/CryptoCards.jsx
+++ b/src/components/CryptoCards.jsx
@@ -20,8 +20,8 @@ const CryptoCards = () => {
 
 const cryptoCards = currencies.map((coin, i) => {
   return (
-    <Grid.Column>
-      <Card key={i} data-cy="crypto-card">
+    <Grid.Column key={i}>
+      <Card data-cy="crypto-card">
         <Card.Content>
           <Card.Header data-cy="crypto-header">
             {coin.name}

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -4,40 +4,41 @@ import { getNewsData } from '../modules/dataCenter'
 
 const CryptoNews = ({ authenticated }) => {
   const [errorMessage, setErrorMessage] = useState()
-
   const [news, setNews] = useState([])
+
+  useEffect(async () => {
+    try {
+      let response = await getNewsData()
+      setNews(response)
+      debugger
+    }
+    catch (error) {
+    }
+  }, [authenticated])
+
   const newsList = news.map((article, i) => {
-    return(
-      <Item key={i}>
-        <Item.Image src={article.urlToImage}/>
+    return (
+      <Item key={i} data-cy="news-article">
+        <Item.Image src={article.urlToImage} />
         <Item.Content>
           <Item.Header>{article.title}</Item.Header>
-          <Item.Meta>{article.date}</Item.Meta>
+          <Item.Meta>Written on: {article.date}</Item.Meta>
           <Item.Description>{article.description}</Item.Description>
         </Item.Content>
       </Item>
     )
   })
-  useEffect(() => {
-    const asyncFetch = async () => {
-      try {
-        let response = await getNewsData()
-      }
-      catch (error) {
-      }
-    }
-  }, [authenticated])
 
   return (
     <>
-      <Grid.Row>
+      <Grid.Row centered>
         <Header data-cy="news-header">Latest Crypto News</Header>
       </Grid.Row>
-      <Grid.Row>
-        <Segment data-cy="news-list-wrapper">
+      <Grid.Row >
+        <Segment >
           {authenticated ? (
             <Item.Group>
-              HELLO YOURE IN!
+               {newsList}
             </Item.Group>
           ) : (
               <Header data-cy="news-auth-error" >

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -1,10 +1,23 @@
 import React, { useEffect, useState } from 'react'
-import { Grid, Header, Segment, Item } from 'semantic-ui-react'
+import { Grid, Header, Segment, Item, StepTitle } from 'semantic-ui-react'
 import { getNewsData } from '../modules/dataCenter'
 
 const CryptoNews = ({ authenticated }) => {
   const [errorMessage, setErrorMessage] = useState()
 
+  const [news, setNews] = useState([])
+  const newsList = news.map((article, i) => {
+    return(
+      <Item key={i}>
+        <Item.Image src={article.urlToImage}/>
+        <Item.Content>
+          <Item.Header>{article.title}</Item.Header>
+          <Item.Meta>{article.date}</Item.Meta>
+          <Item.Description>{article.description}</Item.Description>
+        </Item.Content>
+      </Item>
+    )
+  })
   useEffect(() => {
     const asyncFetch = async () => {
       try {

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -10,15 +10,15 @@ const CryptoNews = ({ authenticated }) => {
     try {
       let response = await getNewsData()
       setNews(response)
-      debugger
     }
     catch (error) {
+      setErrorMessage(error.message)
     }
   }, [authenticated])
 
   const newsList = news.map((article, i) => {
     return (
-      <Item key={i} data-cy="news-article">
+      <Item key={i} className="news-article" data-cy="news-article">
         <Item.Image src={article.urlToImage} />
         <Item.Content>
           <Item.Header>{article.title}</Item.Header>
@@ -31,18 +31,17 @@ const CryptoNews = ({ authenticated }) => {
 
   return (
     <>
-      <Grid.Row centered>
+      <Grid.Row className="news-wrapper">
         <Segment >
           {authenticated ? (
             <Item.Group>
-               {newsList}
+              {newsList}
             </Item.Group>
           ) : (
               <Header data-cy="news-auth-error" >
-                You will need to login in order to see the news.
+                {errorMessage ? errorMessage : 'You will need to login in order to see the news.'}
               </Header>
             )}
-
         </Segment>
       </Grid.Row>
     </>

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -25,15 +25,15 @@ const CryptoNews = ({ authenticated }) => {
 
   return (
     <>
-    
+
       {authenticated ? (
-          <Grid.Row className="news-wrapper">
-          <Segment >
-            <Item.Group divided>
-              {newsList}
-            </Item.Group>
-          </Segment>
-           </Grid.Row >
+        <Grid.Row column={1} >
+            <Segment className="news-wrapper">
+              <Item.Group divided>
+                {newsList}
+              </Item.Group>
+            </Segment>
+        </Grid.Row >
       ) : (
           <Grid.Row centered>
             <Segment >
@@ -41,9 +41,9 @@ const CryptoNews = ({ authenticated }) => {
                 You will need to login in order to see the news.
               </Header>
             </Segment>
-            </Grid.Row>
-          )}
-     
+          </Grid.Row>
+        )}
+
     </>
   )
 }

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -1,18 +1,19 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid, Header, Segment, Item } from 'semantic-ui-react'
 import { getNewsData } from '../modules/dataCenter'
 
 const CryptoNews = ({ authenticated }) => {
+  const [errorMessage, setErrorMessage] = useState()
 
-  useEffect(async () => {
-    try {
-      let response = await getNewsData()
+  useEffect(() => {
+    const asyncFetch = async () => {
+      try {
+        let response = await getNewsData()
+      }
+      catch (error) {
+      }
     }
-    catch (error) {
-      debugger
-    }
-
-  }, [])
+  }, [authenticated])
 
   return (
     <>
@@ -21,9 +22,16 @@ const CryptoNews = ({ authenticated }) => {
       </Grid.Row>
       <Grid.Row>
         <Segment data-cy="news-list-wrapper">
-          <Item.Group>
+          {authenticated ? (
+            <Item.Group>
+              HELLO YOURE IN!
+            </Item.Group>
+          ) : (
+              <Header data-cy="news-auth-error" >
+                You will need to login in order to see the news.
+              </Header>
+            )}
 
-          </Item.Group>
         </Segment>
       </Grid.Row>
     </>

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -1,24 +1,18 @@
 import React, { useEffect, useState } from 'react'
-import { Grid, Header, Segment, Item, StepTitle } from 'semantic-ui-react'
+import { Grid, Header, Segment, Item } from 'semantic-ui-react'
 import { getNewsData } from '../modules/dataCenter'
 
 const CryptoNews = ({ authenticated }) => {
-  const [errorMessage, setErrorMessage] = useState()
   const [news, setNews] = useState([])
 
   useEffect(async () => {
-    try {
-      let response = await getNewsData()
-      setNews(response)
-    }
-    catch (error) {
-      setErrorMessage(error.message)
-    }
+    let response = await getNewsData()
+    setNews(response)
   }, [authenticated])
 
   const newsList = news.map((article, i) => {
     return (
-      <Item key={i} className="news-article" data-cy="news-article">
+      <Item as='a' href={article.url} key={i} className="news-article" data-cy="news-article">
         <Item.Image src={article.urlToImage} />
         <Item.Content>
           <Item.Header>{article.title}</Item.Header>
@@ -31,19 +25,25 @@ const CryptoNews = ({ authenticated }) => {
 
   return (
     <>
-      <Grid.Row className="news-wrapper">
-        <Segment >
-          {authenticated ? (
-            <Item.Group>
+    
+      {authenticated ? (
+          <Grid.Row className="news-wrapper">
+          <Segment >
+            <Item.Group divided>
               {newsList}
             </Item.Group>
-          ) : (
+          </Segment>
+           </Grid.Row >
+      ) : (
+          <Grid.Row centered>
+            <Segment >
               <Header data-cy="news-auth-error" >
-                {errorMessage ? errorMessage : 'You will need to login in order to see the news.'}
+                You will need to login in order to see the news.
               </Header>
-            )}
-        </Segment>
-      </Grid.Row>
+            </Segment>
+            </Grid.Row>
+          )}
+     
     </>
   )
 }

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -32,9 +32,6 @@ const CryptoNews = ({ authenticated }) => {
   return (
     <>
       <Grid.Row centered>
-        <Header data-cy="news-header">Latest Crypto News</Header>
-      </Grid.Row>
-      <Grid.Row >
         <Segment >
           {authenticated ? (
             <Item.Group>

--- a/src/components/CryptoNews.jsx
+++ b/src/components/CryptoNews.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react'
+import { Grid, Header, Segment, Item } from 'semantic-ui-react'
+import { getNewsData } from '../modules/dataCenter'
+
+const CryptoNews = ({ authenticated }) => {
+
+  useEffect(async () => {
+    try {
+      let response = await getNewsData()
+    }
+    catch (error) {
+      debugger
+    }
+
+  }, [])
+
+  return (
+    <>
+      <Grid.Row>
+        <Header data-cy="news-header">Latest Crypto News</Header>
+      </Grid.Row>
+      <Grid.Row>
+        <Segment data-cy="news-list-wrapper">
+          <Item.Group>
+
+          </Item.Group>
+        </Segment>
+      </Grid.Row>
+    </>
+  )
+}
+
+export default CryptoNews

--- a/src/components/MarketCapCard.jsx
+++ b/src/components/MarketCapCard.jsx
@@ -23,7 +23,7 @@ class MarketCapCard extends React.Component {
     let dailyChange = market_data[1] && ((market_data[market_data.length - 1].market_cap / market_data[market_data.length - 2].market_cap - 1) * 100).toFixed(1)
 
     return (
-      <Card key={1} className="market-card">
+      <Card className="market-card">
         <Card.Content>
           {market_data[1] ? (
             <>

--- a/src/components/MarketCapCard.jsx
+++ b/src/components/MarketCapCard.jsx
@@ -28,10 +28,10 @@ class MarketCapCard extends React.Component {
           {market_data[1] ? (
             <>
               <Card.Header data-cy="daily-cap">
-                <span>Total Market Cap: </span><span>{dailyCap}</span>
+                <span className="float-left">Total Market Cap: </span><span className="float-right">{dailyCap}</span>
               </Card.Header>
               <Card.Header data-cy="daily-change">
-                <span>Daily Change: </span><span>{dailyChange}%</span>
+                <span className="float-left">Daily Change: </span><span className="float-right">{dailyChange}%</span>
               </Card.Header>
               <div data-cy="market-chart" >
                 <MarketChart market_data={market_data} />

--- a/src/components/MarketCapCard.jsx
+++ b/src/components/MarketCapCard.jsx
@@ -23,7 +23,7 @@ class MarketCapCard extends React.Component {
     let dailyChange = market_data[1] && ((market_data[market_data.length - 1].market_cap / market_data[market_data.length - 2].market_cap - 1) * 100).toFixed(1)
 
     return (
-      <Card className="market-card">
+      <Card key={1} className="market-card">
         <Card.Content>
           {market_data[1] ? (
             <>

--- a/src/components/RegistrationModal.jsx
+++ b/src/components/RegistrationModal.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
-import { registration } from '../modules/dataCenter'
+import { registration, signIn } from '../modules/dataCenter'
 import { Button, Modal, Form, Grid, Header, Message, Segment, Input } from 'semantic-ui-react'
 
 const RegistrationModal = (props) => {
   const [open, setOpen] = useState(false)
+  const [secondOpen, setSecondOpen] = useState(false)
   const [errorMessage, setErrorMessage] = useState()
 
   const registerUser = async (event) => {
@@ -19,61 +20,135 @@ const RegistrationModal = (props) => {
       setOpen(false)
     }
     catch (error) {
-      debugger
-      setErrorMessage(error.response.data.errors.full_messages)
+      error.response ? (
+        setErrorMessage(error.response.data.errors.full_messages)
+      ) : setErrorMessage("Couldn't connect to the server! Please try again later!")
+    }
+  }
+
+  const signInUser = async (event) => {
+    event.preventDefault()
+    let credentials = {
+      email: event.target.email.value,
+      password: event.target.password.value
+    }
+    try {
+      await signIn(credentials)
+      props.setAuthenticated(true)
+      setSecondOpen(false)
+    }
+    catch (error) {
+      error.response ? (
+        setErrorMessage(error.response.data.errors.full_messages)
+      ) : setErrorMessage("Couldn't connect to the server! Please try again later!")
     }
   }
 
   return (
-    <Modal
-      onClose={() => setOpen(false)}
-      onOpen={() => setOpen(true)}
-      open={open}
-      trigger={<Button color="teal" data-cy="register-button">Register/Sign in</Button>}
-    >
-      <Grid className="login-modal" textAlign='center' style={{ height: '100vh' }} verticalAlign='middle'>
-        <Grid.Column style={{ maxWidth: 450 }}>
-          <Header as='h2' color='teal' textAlign='center'>
-            Login to view the latest crypto news!
+    <>
+      <Modal
+        onClose={() => {
+          setOpen(false)
+          setErrorMessage()
+        }}
+        onOpen={() => setOpen(true)}
+        open={open}
+        trigger={<Button color="teal" data-cy="register-button">Register/Sign in</Button>}
+      >
+        <Grid className="login-modal" textAlign='center' style={{ height: '100vh' }} verticalAlign='middle'>
+          <Grid.Column style={{ maxWidth: 450 }}>
+            <Header as='h2' color='teal' textAlign='center'>
+              Login to view the latest crypto news!
             </Header>
-          {errorMessage &&
-            <p data-cy="error-message">{errorMessage}</p>
-          }
-          <Form onSubmit={(event) => registerUser(event)} data-cy='registration-form' size='large'>
-            <Segment stacked>
-              <Form.Field
-                data-cy='email-field'
-                name="email"
-                control={Input}
-                type="email"
-                label='email'
-                placeholder='email'
-              />
-              <Form.Field
-                data-cy='password-field'
-                name="password"
-                control={Input}
-                type="password"
-                label='password'
-                placeholder='password'
-              />
-              <Form.Field
-                data-cy='password-confirmation-field'
-                name="password_confirmation"
-                control={Input}
-                type="password"
-                label='confirm password'
-                placeholder='retype password'
-              />
-              <Button data-cy='submit' color="teal" type='submit'>Register!</Button>
-            </Segment>
-          </Form>
-          <Message>
-            Already have an account? <a href='/'>Sign In</a>
-          </Message>
-        </Grid.Column>
-      </Grid>
-    </Modal>
+            {errorMessage &&
+              <p style={{ color: 'white' }} data-cy="error-message">{errorMessage}</p>
+            }
+            <Form onSubmit={(event) => registerUser(event)} data-cy='registration-form' size='large'>
+              <Segment stacked>
+                <Form.Field
+                  data-cy='email-field'
+                  name="email"
+                  control={Input}
+                  type="email"
+                  label='email'
+                  placeholder='email'
+                />
+                <Form.Field
+                  data-cy='password-field'
+                  name="password"
+                  control={Input}
+                  type="password"
+                  label='password'
+                  placeholder='password'
+                />
+                <Form.Field
+                  data-cy='password-confirmation-field'
+                  name="password_confirmation"
+                  control={Input}
+                  type="password"
+                  label='confirm password'
+                  placeholder='retype password'
+                />
+                <Button data-cy='submit' color="green" type='submit'>Register!</Button>
+              </Segment>
+            </Form>
+            <Message>
+              Already have an account?
+             <br></br>
+              <Button
+                size="tiny"
+                color="green"
+                onClick={() => {
+                  setOpen(false)
+                  setSecondOpen(true)
+                }}>
+                Sign in!
+             </Button>
+            </Message>
+          </Grid.Column>
+        </Grid>
+      </Modal>
+
+      <Modal
+        onClose={() => {
+          setSecondOpen(false)
+          setErrorMessage()
+        }}
+        open={secondOpen}
+      >
+        <Grid className="login-modal" textAlign='center' style={{ height: '100vh' }} verticalAlign='middle'>
+          <Grid.Column style={{ maxWidth: 450 }}>
+            <Header as='h2' color='teal' textAlign='center'>
+              Welcome back!
+            </Header>
+            {errorMessage &&
+              <p style={{ color: 'white' }} data-cy="error-message">{errorMessage}</p>
+            }
+            <Form onSubmit={(event) => signInUser(event)} data-cy='registration-form' size='large'>
+              <Segment stacked>
+                <Form.Field
+                  data-cy='email-field'
+                  name="email"
+                  control={Input}
+                  type="email"
+                  label='email'
+                  placeholder='email'
+                />
+                <Form.Field
+                  data-cy='password-field'
+                  name="password"
+                  control={Input}
+                  type="password"
+                  label='password'
+                  placeholder='password'
+                />
+                <Button data-cy='submit' color="green" type='submit'>Sign in!</Button>
+              </Segment>
+            </Form>
+          </Grid.Column>
+        </Grid>
+      </Modal>
+    </>
   )
 }
 

--- a/src/components/RegistrationModal.jsx
+++ b/src/components/RegistrationModal.jsx
@@ -14,8 +14,7 @@ const RegistrationModal = (props) => {
       password_confirmation: event.target.password_confirmation.value
     }
     try {
-      let [response, userCredentials] = await registration(credentials)
-      localStorage.setItem('credentials', JSON.stringify(userCredentials))
+      await registration(credentials)
       props.setAuthenticated(true)
       setOpen(false)
     }

--- a/src/components/RegistrationModal.jsx
+++ b/src/components/RegistrationModal.jsx
@@ -69,7 +69,7 @@ const RegistrationModal = (props) => {
             </Segment>
           </Form>
           <Message>
-            Already have an account? <a href='/menu'>Sign In</a>
+            Already have an account? <a href='/'>Sign In</a>
           </Message>
         </Grid.Column>
       </Grid>

--- a/src/components/RegistrationModal.jsx
+++ b/src/components/RegistrationModal.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react'
+import { registration } from '../modules/dataCenter'
+import { Button, Modal, Form, Grid, Header, Message, Segment, Input } from 'semantic-ui-react'
+
+const RegistrationModal = (props) => {
+  const [open, setOpen] = useState(false)
+  const [errorMessage, setErrorMessage] = useState()
+
+  const registerUser = async (event) => {
+    event.preventDefault()
+    let credentials = {
+      email: event.target.email.value,
+      password: event.target.password.value,
+      password_confirmation: event.target.password_confirmation.value
+    }
+    try {
+      let [response, userCredentials] = await registration(credentials)
+      localStorage.setItem('credentials', JSON.stringify(userCredentials))
+      props.setAuthenticated(true)
+      setOpen(false)
+    }
+    catch (error) {
+      debugger
+      setErrorMessage(error.response.data.errors.full_messages)
+    }
+  }
+
+  return (
+    <Modal
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      open={open}
+      trigger={<Button color="teal" data-cy="register-button">Register/Sign in</Button>}
+    >
+      <Grid className="login-modal" textAlign='center' style={{ height: '100vh' }} verticalAlign='middle'>
+        <Grid.Column style={{ maxWidth: 450 }}>
+          <Header as='h2' color='teal' textAlign='center'>
+            Login to view the latest crypto news!
+            </Header>
+          {errorMessage &&
+            <p data-cy="error-message">{errorMessage}</p>
+          }
+          <Form onSubmit={(event) => registerUser(event)} data-cy='registration-form' size='large'>
+            <Segment stacked>
+              <Form.Field
+                data-cy='email-field'
+                name="email"
+                control={Input}
+                type="email"
+                label='email'
+                placeholder='email'
+              />
+              <Form.Field
+                data-cy='password-field'
+                name="password"
+                control={Input}
+                type="password"
+                label='password'
+                placeholder='password'
+              />
+              <Form.Field
+                data-cy='password-confirmation-field'
+                name="password_confirmation"
+                control={Input}
+                type="password"
+                label='confirm password'
+                placeholder='retype password'
+              />
+              <Button data-cy='submit' color="teal" type='submit'>Register!</Button>
+            </Segment>
+          </Form>
+          <Message>
+            Already have an account? <a href='/menu'>Sign In</a>
+          </Message>
+        </Grid.Column>
+      </Grid>
+    </Modal>
+  )
+}
+
+export default RegistrationModal

--- a/src/modules/dataCenter.js
+++ b/src/modules/dataCenter.js
@@ -21,6 +21,7 @@ const getNewsData = async () => {
   let date = new Date()
   date.setDate(date.getDate() - 5);
   date = date.toLocaleDateString('en-CA')
+
   let response = await axios.get('/api/news',
     { date: date },
     { headers: credentials })
@@ -36,7 +37,7 @@ const registration = async (credentials) => {
     expiry: response.headers['expiry'],
     token_type: 'Bearer'
   }
-  return [response, userCredentials]
+  localStorage.setItem('credentials', JSON.stringify(userCredentials))
 }
 
 export { getMarketCapData, getCoinData, registration, getNewsData };

--- a/src/modules/dataCenter.js
+++ b/src/modules/dataCenter.js
@@ -18,13 +18,11 @@ const getCoinData = async () => {
 
 const getNewsData = async () => {
   let credentials = JSON.parse(localStorage.getItem('credentials'))
-  let date = new Date()
-  date.setDate(date.getDate() - 5);
-  date = date.toLocaleDateString('en-CA')
+  let today = new Date()
+  today.setDate(today.getDate() - 5);
+  let fiveDaysAgo = today.toLocaleDateString('en-CA')
 
-  let response = await axios.get('/api/news',
-    { date: date },
-    { headers: credentials })
+  let response = await axios.get(`/api/news?date=${fiveDaysAgo}`, {headers: credentials})
   return response.data.articles
 }
 

--- a/src/modules/dataCenter.js
+++ b/src/modules/dataCenter.js
@@ -38,5 +38,17 @@ const registration = async (credentials) => {
   localStorage.setItem('credentials', JSON.stringify(userCredentials))
 }
 
-export { getMarketCapData, getCoinData, registration, getNewsData };
+const signIn = async (credentials) => {
+  let response = await axios.post('/api/auth/sign_in', credentials)
+  let userCredentials = {
+    uid: response.headers['uid'],
+    access_token: response.headers['access-token'],
+    client: response.headers['client'],
+    expiry: response.headers['expiry'],
+    token_type: 'Bearer'
+  }
+  localStorage.setItem('credentials', JSON.stringify(userCredentials))
+}
+
+export { getMarketCapData, getCoinData, registration, getNewsData, signIn };
 

--- a/src/modules/dataCenter.js
+++ b/src/modules/dataCenter.js
@@ -19,10 +19,13 @@ const getCoinData = async () => {
 const getNewsData = async () => {
   let credentials = JSON.parse(localStorage.getItem('credentials'))
   let date = new Date()
+  date.setDate(date.getDate() - 5);
+  date = date.toLocaleDateString('en-CA')
   let response = await axios.get('/api/news',
     { date: date },
     { headers: credentials })
   debugger
+  return response.data.articles
 }
 
 const registration = async (credentials) => {

--- a/src/modules/dataCenter.js
+++ b/src/modules/dataCenter.js
@@ -16,5 +16,17 @@ const getCoinData = async () => {
   return response.data.currencies
 }
 
-export { getMarketCapData, getCoinData };
+const registration = async (credentials) => {
+  let response = await axios.post('/api/auth', credentials)
+  let userCredentials = {
+    uid: response.headers['uid'],
+    access_token: response.headers['access-token'],
+    client: response.headers['client'],
+    expiry: response.headers['expiry'],
+    token_type: 'Bearer'
+  }
+  return [response, userCredentials]
+}
+
+export { getMarketCapData, getCoinData, registration };
 

--- a/src/modules/dataCenter.js
+++ b/src/modules/dataCenter.js
@@ -8,12 +8,21 @@ const getMarketCapData = async () => {
   today = today.toISOString().split('today')[0]
 
   let response = await axios.get(`/api/markets?date=${today}`);
-  return response.data.market_data 
+  return response.data.market_data
 }
 
 const getCoinData = async () => {
   let response = await axios.get('/api/currencies')
   return response.data.currencies
+}
+
+const getNewsData = async () => {
+  let credentials = JSON.parse(localStorage.getItem('credentials'))
+  let date = new Date()
+  let response = await axios.get('/api/news',
+    { date: date },
+    { headers: credentials })
+  debugger
 }
 
 const registration = async (credentials) => {
@@ -28,5 +37,5 @@ const registration = async (credentials) => {
   return [response, userCredentials]
 }
 
-export { getMarketCapData, getCoinData, registration };
+export { getMarketCapData, getCoinData, registration, getNewsData };
 

--- a/src/modules/dataCenter.js
+++ b/src/modules/dataCenter.js
@@ -24,7 +24,6 @@ const getNewsData = async () => {
   let response = await axios.get('/api/news',
     { date: date },
     { headers: credentials })
-  debugger
   return response.data.articles
 }
 


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/177037893)
### User Story 
``` 
As a visitor
In order to access crypto news
I need the news tab to become visible upon registration/signing in
``` 
## Changes proposed in this pull request: 
* Registration and sign in functionality
* List of latest crypto news for authenticated users
* Thematic styling
## What I have learned working on this feature: 
* Diving further into Semantic with loaders and dimmers
* Creating a double Modal
## Screenshots (Client) 
![Screenshot from 2021-02-27 12-31-02](https://user-images.githubusercontent.com/75306727/109386186-484b0d00-78f9-11eb-95dd-0cc613b188cc.png)
![Screenshot from 2021-02-27 12-31-06](https://user-images.githubusercontent.com/75306727/109386188-497c3a00-78f9-11eb-9183-ae5fb6b9e87e.png)
![Screenshot from 2021-02-27 12-42-27](https://user-images.githubusercontent.com/75306727/109386189-4a14d080-78f9-11eb-97f7-d176baf6a0ff.png)
